### PR TITLE
Update nodejs to lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3; \
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
-ENV NODE_VERSION 13.0.0
+ENV NODE_VERSION 14.16.0
 
 # https://github.com/nodejs/docker-node/blob/910f8b1c0bdeee7bd464f0875297954bb86de9da/14/stretch/Dockerfile#L8
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
Due to this error: 
```
yarn install v1.22.10
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@2.1.3: The platform "linux" is incompatible with this module.
info "fsevents@2.1.3" is an optional dependency and failed compatibility check. Excluding it from installation.
info fsevents@2.3.2: The platform "linux" is incompatible with this module.
info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
error browserslist@4.16.3: The engine "node" is incompatible with this module. Expected version "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7". Got "13.0.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Exited with code exit status 1
```